### PR TITLE
fix: workflows

### DIFF
--- a/.github/workflows/corndogs_release.yaml
+++ b/.github/workflows/corndogs_release.yaml
@@ -52,7 +52,7 @@ jobs:
           username: ${{ secrets.QUAY_DOCKER_REGISTRY_USER }}
           password: ${{ secrets.QUAY_DOCKER_REGISTRY_PASSWORD }}
           tag-versions: "latest,${{ steps.semver-tags.outputs.new_release_version }}"
-          docker-context: "./corndogs"
+          docker-context: "./corndogs/"
 
       - if: steps.semver-tags.outputs.new_release_published == 'true'
         name: Update chart appVersion

--- a/.github/workflows/helm_release.yaml
+++ b/.github/workflows/helm_release.yaml
@@ -66,6 +66,7 @@ jobs:
       - if: steps.semver-tags.outputs.new_release_published == 'true'
         name: Upload chart
         uses: catalystcommunity/action-upload-chart-git@v1
-        token: ${{ secrets.AUTOMATION_PAT }}
-        tag: ${{ steps.semver-tags.outputs.new_release_git_tag }}
-        release-asset-label-contains: "Helm_chart"
+        with:
+          token: ${{ secrets.AUTOMATION_PAT }}
+          tag: ${{ steps.semver-tags.outputs.new_release_git_tag }}
+          release-asset-label-contains: "Helm_chart"

--- a/.github/workflows/protos_release.yaml
+++ b/.github/workflows/protos_release.yaml
@@ -58,20 +58,6 @@ jobs:
         run: |
           ./.github/scripts/make_general_release.sh "${RELEASE_NAME}"
       - if: steps.semver-tags.outputs.new_release_published == 'true'
-        name: Push protos to buf BSR
-        uses: catalystsquad/action-buf@v2
-        with:
-          token: ${{ secrets.AUTOMATION_PAT }}
-          buf-user: ${{ secrets.BUF_USER }}
-          buf-token: ${{ secrets.BUF_TOKEN }}
-          lint: false
-          generate: false
-          breaking: false
-          mod-prune: false
-          mod-update: false
-          push: true
-          push-dir: protos/corndogsapis
-      - if: steps.semver-tags.outputs.new_release_published == 'true'
         name: Install UV
         run: wget -qO- https://astral.sh/uv/install.sh | sh
       - if: steps.semver-tags.outputs.new_release_published == 'true'


### PR DESCRIPTION
- remove push to BSR, we don't need it and it was failing due to no token.
- Fix helm chart push action syntax.
- Added a trailing slash to the docker context for corndogs, which hopefully fixes the image build.