### PR TITLE
fix: GetNextTask no longer returns latest updated task within same priority. Now returns oldest.

### DIFF
--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -33,11 +33,12 @@ jobs:
       - name: Dump Context
         uses: crazy-max/ghaction-dump-context@v2
       - name: Run Tests
-        uses: catalystsquad/action-kind-test@v1
+        uses: catalystscommunity/action-kind-test@v1
         with:
           token: ${{ github.token }}
           ref: ${{ github.ref }}
           wait-for-ports: 5080
+          skaffold-working-directory: "corndogs"
           add-private-helm-repo: "true"
           helm-repo-name: catalystcommunity
           helm-repo-url: https://catalystcommunity.github.io/charts

--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -33,7 +33,7 @@ jobs:
       - name: Dump Context
         uses: crazy-max/ghaction-dump-context@v2
       - name: Run Tests
-        uses: catalystscommunity/action-kind-test@v1
+        uses: catalystcommunity/action-kind-test@v1
         with:
           token: ${{ github.token }}
           ref: ${{ github.ref }}

--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -44,4 +44,5 @@ jobs:
           helm-repo-url: https://catalystcommunity.github.io/charts
           helm-repo-username: ${{ github.token }}
           helm-repo-password: ${{ github.token }}
+          go-version: "1.23.x"
           test-command: go test -v ./...

--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -38,7 +38,7 @@ jobs:
           token: ${{ github.token }}
           ref: ${{ github.ref }}
           wait-for-ports: 5080
-          skaffold-working-directory: "corndogs"
+          skaffold-working-directory: ./corndogs
           add-private-helm-repo: "true"
           helm-repo-name: catalystcommunity
           helm-repo-url: https://catalystcommunity.github.io/charts

--- a/corndogs/server/store/postgresstore/postgresstore.go
+++ b/corndogs/server/store/postgresstore/postgresstore.go
@@ -136,7 +136,7 @@ func (s PostgresStore) GetNextTask(ctx context.Context, req *corndogsv1alpha1.Ge
 				 WHERE uuid = (
 					 SELECT uuid FROM tasks
 					 WHERE queue = ? AND current_state = ?
-                     ORDER BY priority DESC, update_time DESC
+                     ORDER BY priority DESC, update_time ASC
 					 FOR UPDATE SKIP LOCKED
 					 LIMIT 1)
 				 RETURNING uuid`,

--- a/corndogs/skaffold.yaml
+++ b/corndogs/skaffold.yaml
@@ -7,6 +7,7 @@ portForward:
   # pf for grpc server
   - resourceType: service
     resourceName: corndogs
+    namespace: skaffoldcorndogs
     port: 5080
     localPort: 5080
   # pf for prometheus metrics
@@ -17,6 +18,7 @@ portForward:
   # pf for postgresdb
   - resourceType: service
     resourceName: corndogs-postgresql
+    namespace: skaffoldcorndogs
     port: 5432
     localPort: 5432
 deploy:


### PR DESCRIPTION
This fixes an issue noted in the old repo here: https://github.com/TnLCommunity/corndogs/issues/58

The priority returned by `GetNextTask` was correct, but it was incorrectly returning the *latest* updated task, so old tasks could take much longer to get picked up.

This PR fixes that, so the oldest tasks within the highest priority get picked up first.